### PR TITLE
GEOPY-1862: for pypi, use dedicated package.rst as long description (readme field) instead of README.rst

### DIFF
--- a/THIRD_PARTY_SOFTWARE.rst
+++ b/THIRD_PARTY_SOFTWARE.rst
@@ -1,7 +1,7 @@
 Third-party software
 ====================
 
-The mira-omf repository and source distributions bundle several libraries that are
+The params-sweep repository and source distributions bundle several libraries that are
 compatibly licensed.  We list these here.
 
 .. list-table::

--- a/package.rst
+++ b/package.rst
@@ -1,0 +1,64 @@
+Params-sweep
+============
+
+The **params-sweep** package lets users generate and run ui.json applications over a suite of values.
+
+
+Installation
+^^^^^^^^^^^^
+**params-sweep** is currently written for Python 3.10 or higher.
+
+Install **params-sweep** from PyPI::
+
+    $ pip install params-sweep
+
+
+Feedback
+^^^^^^^^
+Have comments or suggestions? Submit feedback.
+All the content can be found on the github_ repository.
+
+.. _github: https://github.com/MiraGeoscience/params-sweep
+
+
+Visit `Mira Geoscience website <https://mirageoscience.com/>`_ to learn more about our products
+and services.
+
+
+License
+^^^^^^^
+MIT License
+
+Copyright (c) 2020-2025 Mira Geoscience
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Third Party Software
+^^^^^^^^^^^^^^^^^^^^
+The params-sweep Software may provide links to third party libraries or code (collectively “Third Party Software”)
+to implement various functions. Third Party Software does not comprise part of the Software.
+The use of Third Party Software is governed by the terms of such software license(s).
+Third Party Software notices and/or additional terms and conditions are located in the
+`THIRD_PARTY_SOFTWARE.rst`_ file.
+
+.. _THIRD_PARTY_SOFTWARE.rst: ./THIRD_PARTY_SOFTWARE.rst
+
+Copyright
+^^^^^^^^^
+Copyright (c) 2024-2025 Mira Geoscience Ltd.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "param-sweeps"
 version = "0.3.0-alpha.1"
 
-description = "Parameter sweeper for ui.json powered applications"
+description = "Parameter sweeper for ui.json powered applications."
 license = "MIT"
 authors = ["Mira Geoscience <support@mirageoscience.com>"]
 maintainers = ["Benjamin Kary <benjamink@mirageoscience.com>"]
@@ -10,7 +10,7 @@ repository = "https://github.com/MiraGeoscience/param-sweeps"
 #documentation  = "https://mirageoscience-param-sweeps.readthedocs-hosted.com/"
 homepage = "https://www.mirageoscience.com/mining-industry-software/python-integration/"
 
-readme = "README.rst"
+readme = "package.rst"
 keywords = ["geology", "geophysics", "earth sciences"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -30,7 +30,6 @@ include = [
     { path = "COPYING" },
     { path = "COPYING.LESSER" },
     { path = "LICENSE" },
-    { path = "README.rst" },
     { path = "THIRD_PARTY_SOFTWARE.rst" },
     { path = "docs/**/THIRD_PARTY_SOFTWARE.rst" },
 ]


### PR DESCRIPTION
**GEOPY-1862 - for pypi, use dedicated package.rst as long description (readme field) instead of README.rst**
