### PR TITLE
DEVOPS-690: updated workflow to use devops-690-poetry2 branch for testing poetry to accepts old pyproject.toml in CI

### DIFF
--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -24,14 +24,14 @@ concurrency:
 jobs:
   call-workflow-static-analysis:
     name: Static analysis
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@DEVOPS-690-poetry2
     with:
       package-manager: 'poetry'
       app-name: 'param_sweeps'
       python-version: '3.10'
   call-workflow-pytest:
     name: Pytest
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@DEVOPS-690-poetry2
     with:
       package-manager: 'poetry'
       python-versions: '["3.10", "3.11", "3.12"]'


### PR DESCRIPTION
**DEVOPS-690 - use Poetry 2 and have pyproject.toml checked by pre-commit**
…testing poetry to accepts old toml